### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -9,7 +9,7 @@
     "Tinky::Hash":      "lib/Tinky/Hash.pm6"
   },
   "source-url":         "git://github.com/MARTIMM/tinky-hash.git",
-  "license":            "The Artistic License 2.0",
+  "license":            "Artistic-2.0",
   "authors":            "Marcel Timmerman",
   "support": {
     "email":            "mt1957@gmail.com"


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license